### PR TITLE
Add header-only option

### DIFF
--- a/include/boost/stacktrace.hpp
+++ b/include/boost/stacktrace.hpp
@@ -47,3 +47,6 @@ std::basic_ostream<CharT, TraitsT>& operator<<(std::basic_ostream<CharT, TraitsT
 
 }} // namespace boost::stacktrace
 
+#if defined(BOOST_STACKTRACE_HEADER_ONLY)
+    #include <boost/stacktrace/detail/stacktrace.ipp>
+#endif


### PR DESCRIPTION
similar feature to Boost.Chrono `BOOST_CHRONO_HEADER_ONLY`.

```cpp
#define BOOST_STACKTRACE_HEADER_ONLY
#define BOOST_STACKTRACE_USE_BACKTRACE
#include <iostream>
#include <boost/stacktrace.hpp>

int main()
{
    std::cout << boost::stacktrace::stacktrace();
}
```